### PR TITLE
Fix: junction footprint account for splitting

### DIFF
--- a/include/JunctionBuilder.h
+++ b/include/JunctionBuilder.h
@@ -14,8 +14,11 @@
 
 #pragma once
 
+#define NOMINMAX // makes std::numeric_limits<int>::max() work
+
 #include <set>
 #include <string>
+#include <limits> // for std::numeric_limits
 
 #include <windows.h>
 #include <commdlg.h> // for GetOpenFileName


### PR DESCRIPTION
* Fix: When calculating the footprint of a junction box, the program now accounts for splitting the box. There are some situations where the cables would be able fit on all of the terminals in the box, but there's no way to split the cables into two tables without overflowing one of the tables. This is now accounted for, and the `Junction Box Setup` dialog box now greys-out sizes that cant fit cables on all of their tables.

* Refactor: Splitting logic has been moved to `_shouldSplit`, which returns `true` when the next cable to be drawn should be moved to the next table.