### PR TITLE
Change OpenXLSX to a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 build/
 cmake/
 
-# External libraries (if they contain compiled or temporary files)
-external/*
-
 # Ignore build artifacts from CMake
 CMakeFiles/
 *.dir/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/wxWidgets"]
-	path = external/wxWidgets
-	url = https://github.com/wxWidgets/wxWidgets.git
 [submodule "external/OpenXLSX"]
 	path = external/OpenXLSX
 	url = https://github.com/troldal/OpenXLSX.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/wxWidgets"]
+	path = external/wxWidgets
+	url = https://github.com/wxWidgets/wxWidgets.git
+[submodule "external/OpenXLSX"]
+	path = external/OpenXLSX
+	url = https://github.com/troldal/OpenXLSX.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
 
@@ -49,9 +51,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_directories(${PROJECT_NAME} PRIVATE ${ARX_SDK}/lib-x64)
 
 # Add OpenXLSX
-option(OPENXLSX_LIBRARY_TYPE "STATIC" ON)
-option(OPENXLSX_ENABLE_NOWIDE "OFF")
+set(OPENXLSX_LIBRARY_TYPE "STATIC" CACHE STRING "Type of library to build for OpenXLSX")
 add_subdirectory(external/OpenXLSX)
+
+# Add wxWidgets
+add_subdirectory(external/wxWidgets)
 
 # Link libraries
 target_link_libraries(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,6 @@ set(OPENXLSX_BUILD_SAMPLES OFF CACHE BOOL "Whether to build samples for OpenXLSX
 set(OPENXLSX_BUILD_BENCHMARKS OFF CACHE BOOL "Whether to build benchmarks for OpenXLSX")
 add_subdirectory(external/OpenXLSX)
 
-# Add wxWidgets
-add_subdirectory(external/wxWidgets)
-
 # Link libraries
 target_link_libraries(${PROJECT_NAME}
     accore.lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ target_link_directories(${PROJECT_NAME} PRIVATE ${ARX_SDK}/lib-x64)
 
 # Add OpenXLSX
 set(OPENXLSX_LIBRARY_TYPE "STATIC" CACHE STRING "Type of library to build for OpenXLSX")
+set(OPENXLSX_BUILD_TESTS OFF CACHE BOOL "Whether to build tests for OpenXLSX")
+set(OPENXLSX_BUILD_SAMPLES OFF CACHE BOOL "Whether to build samples for OpenXLSX")
+set(OPENXLSX_BUILD_BENCHMARKS OFF CACHE BOOL "Whether to build benchmarks for OpenXLSX")
 add_subdirectory(external/OpenXLSX)
 
 # Add wxWidgets


### PR DESCRIPTION
* OpenXLSX has been changed to a submodule, preventing the need to manually install and include it
* Experimented with migrating to wxWidgets for dialog box creation and sizing, but had major issues when loading the resultant plugin into AutoCAD. Decided to revisit this at a later date.